### PR TITLE
display the title of the YouTube video as tooltip/hover

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lxd-sphinx-extensions
-version = 0.0.2
+version = 0.0.3
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used in LXD
@@ -16,7 +16,7 @@ python_requires = >=3.6
 install_requires =
     sphinx
     requests
-    bs4
+    beautifulsoup4
     docutils
 
 [options.package_data]


### PR DESCRIPTION
This will retrieve the title of the YouTube video and display it when hovering over the play icon/the "Watch on YouTube" text.

![image](https://user-images.githubusercontent.com/11227796/178277910-2e43c00b-6585-4311-a87b-f9dbc7aefffd.png)


Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>