### PR TITLE
add an extension for custom RST roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,11 @@ For example, in MyST syntax:
 ```{youtube} https://www.youtube.com/watch?v=4iNpiL-lrXU
 ```
 ````
+
+### Custom roles
+
+This extension adds custom roles that can be used in rST.
+
+Currently implemented:
+
+- `spellexception` - Includes the provided text in `<spellexception></spellexception>`, which makes it possible to exclude it from a spell checker.

--- a/custom-rst-roles/__init__.py
+++ b/custom-rst-roles/__init__.py
@@ -1,0 +1,12 @@
+from docutils import nodes
+
+def spellexception_role(name, rawtext, text, lineno, inliner,
+            options=None, content=None):
+    node = nodes.raw(text="<spellexception>"+text+"</spellexception>", format="html")
+    return [node],[]
+
+
+def setup(app):
+    app.add_role("spellexception", spellexception_role)
+
+    return

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lxd-sphinx-extensions
-version = 0.0.3
+version = 0.0.4
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used in LXD
@@ -12,6 +12,7 @@ url = https://github.com/canonical/lxd-sphinx-extensions
 packages =
     related-links
     youtube-links
+    custom-rst-roles
 python_requires = >=3.6
 install_requires =
     sphinx


### PR DESCRIPTION
We need a role to mark up spelling exceptions to remove them
from the spell checker.

There will probably be more custom roles in the future.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>