### PR TITLE
check for exception before copying files

### DIFF
--- a/common.py
+++ b/common.py
@@ -2,10 +2,11 @@ from os import path
 from sphinx.util.fileutil import copy_asset_file
 
 def copy_custom_files(app,exc,filename):
-    if app.builder.format == 'html':
-        staticfile = path.join(app.builder.outdir, '_static',filename)
-        cssfile = path.join(path.dirname(__file__), '_static',filename)
-        copy_asset_file(cssfile, staticfile)
+    if not exc:
+        if app.builder.format == 'html':
+            staticfile = path.join(app.builder.outdir, '_static',filename)
+            cssfile = path.join(path.dirname(__file__), '_static',filename)
+            copy_asset_file(cssfile, staticfile)
 
 
 def add_css(app,filename):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lxd-sphinx-extensions
-version = 0.0.4
+version = 0.0.5
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used in LXD


### PR DESCRIPTION
If the build fails because of another error, the CSS files cannot
be copied. Don't attempt to do so in this case, because the error
message will be confusing and we rather want to see the error that
made the build fail.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>