### PR TITLE
add a domain for configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,69 @@ This extension adds custom roles that can be used in rST.
 Currently implemented:
 
 - `spellexception` - Includes the provided text in `<spellexception></spellexception>`, which makes it possible to exclude it from a spell checker.
+
+### Config options
+
+This extension adds a `:config:option:` directive that you can use to generate expandable configuration options, a `:config:option:` role for linking to those options, and an index that lists all config options.
+
+#### Enable the extension
+
+Add `config-options` to your extensions list in `conf.py` to enable the extension:
+
+    extensions = [
+                  (...),
+                  "config-options"
+                 ]
+
+#### Style the output
+
+The extension comes with a CSS file that implements the classes needed to style the configuration options.
+You can override the style in your own style sheet.
+
+#### Add configuration options
+
+Use the `:config:option:` directive to add a configuration option.
+It takes two parameters: the config option name and the scope.
+If the scope is not provided, `server` is used as the default scope.
+
+You must provide a `:shortdesc:` option.
+Optional options are `:type:`, `:liveupdate:`, `:condition:`, `:readonly:`, `:resource:`, `:managed:`, `:required:`, and `:scope:` (this scope is not related to the option scope specified by the parameter).
+
+You can use formatting in the short description, the options, and the main description.
+When starting a value with markup, or if you want to prevent a value from being processed (for example, to prevent a "no" value to be transformed to "False"), put quotes around the value.
+
+For example, in MyST syntax:
+
+````
+```{config:option} backups.compression_algorithm server
+:shortdesc: Compression algorithm for images
+:type: string
+:scope: global
+:default: "`gzip`"
+
+Compression algorithm to use for new images (`bzip2`, `gzip`, `lzma`, `xz` or `none`)
+```
+````
+
+For more examples, see https://linuxcontainers.org/lxd/docs/latest/networks/config_options_cheat_sheet.
+
+#### Link to configuration options
+
+To link to a configuration option, use the `:config:option:` role.
+You cannot override the link text (which wouldn't make much sense anyway, because it is displayed as code).
+
+For example, in MyST syntax:
+
+```
+{config:option}`instance:migration.incremental.memory.iterations`
+```
+
+#### Link to the index
+
+You can link to the index of configuration options with the `config-options` anchor.
+
+For example, in MyST syntax:
+
+```
+{ref}`config-options`
+```

--- a/common.py
+++ b/common.py
@@ -16,3 +16,11 @@ def add_css(app, filename):
         exc: copy_custom_files(app, exc, filename)
     )
     app.add_css_file(filename)
+
+
+def add_js(app, filename):
+    app.connect(
+        "build-finished", lambda app,
+        exc: copy_custom_files(app, exc, filename)
+    )
+    app.add_js_file(filename)

--- a/config-options/__init__.py
+++ b/config-options/__init__.py
@@ -1,0 +1,198 @@
+from collections import defaultdict
+from docutils import nodes
+from docutils.parsers.rst import directives
+from docutils.statemachine import ViewList
+from sphinx.domains import Domain, Index
+from sphinx.roles import XRefRole
+from sphinx.directives import ObjectDescription
+from sphinx.util.nodes import make_refnode
+from sphinx.errors import SphinxWarning
+from . import common
+
+
+# Parse rST inside an option (":something:")
+def parseOption(obj, option):
+    newNode = nodes.inline()
+    parseNode = ViewList()
+    parseNode.append(option, "parsing", 1)
+    obj.state.nested_parse(parseNode, 0, newNode)
+    return newNode
+
+
+class ConfigOption(ObjectDescription):
+
+    optional_fields = {
+        "type": "Type",
+        "liveupdate": "Live update",
+        "condition": "Condition",
+        "readonly": "Read-only",
+        "resource": "Resource",
+        "managed": "Managed",
+        "required": "Required",
+        "scope": "Scope",
+    }
+
+    required_arguments = 1
+    optional_arguments = 1
+    has_content = True
+    option_spec = {
+        "shortdesc": directives.unchanged_required,
+        "default": directives.unchanged,
+    }
+    for field in optional_fields:
+        option_spec[field] = directives.unchanged
+
+    def run(self):
+
+        # Generate the output
+
+        key = nodes.inline()
+        key += nodes.literal(text=self.arguments[0])
+        key["classes"].append("key")
+
+        shortDesc = parseOption(self, self.options["shortdesc"])
+        shortDesc["classes"].append("shortdesc")
+
+        default = nodes.inline()
+        default["classes"].append("default")
+        if "default" in self.options:
+            default += nodes.strong(text="Default: ")
+            parsedDefault = parseOption(self, self.options["default"])
+            parsedDefault["classes"].append("ignoreP")
+            default += parsedDefault
+
+        firstLine = nodes.container()
+        firstLine["classes"].append("basicinfo")
+        firstLine += key
+        firstLine += shortDesc
+        firstLine += default
+
+        details = nodes.container()
+        details["classes"].append("details")
+        fields = nodes.bullet_list()
+        fields["classes"].append("fields")
+        for field in self.optional_fields:
+            if field in self.options:
+                item = nodes.list_item()
+                item += nodes.strong(text=self.optional_fields[field] + ": ")
+                parsedOption = parseOption(self, self.options[field])
+                parsedOption["classes"].append("ignoreP")
+                item += parsedOption
+                fields += item
+        details += fields
+        self.state.nested_parse(self.content, self.content_offset, details)
+
+        # Create a new container node with the content
+
+        newNode = nodes.container()
+        newNode["classes"].append("configoption")
+        newNode += firstLine
+        newNode += details
+
+        # Create a target
+
+        scope = "server"
+        if len(self.arguments) > 1:
+            scope = self.arguments[1]
+        targetID = scope + ":" + self.arguments[0]
+        targetNode = nodes.target("", "", ids=[targetID])
+
+        # Register the target with the domain
+
+        configDomain = self.env.get_domain("config")
+        configDomain.add_option(self.arguments[0], scope)
+
+        # Return the content and target node
+
+        return [targetNode, newNode]
+
+
+class ConfigIndex(Index):
+
+    # To link to the index: {ref}`config-options`
+    name = "options"
+    localname = "Configuration options"
+
+    def generate(self, docnames=None):
+        content = defaultdict(list)
+
+        options = self.domain.get_objects()
+        # sort by key name
+        options = sorted(options, key=lambda option: option[0])
+
+        for _name, dispname, typ, docname, anchor, _priority in options:
+            # group by scope
+            content[anchor.partition(":")[0]].append(
+                (dispname, 0, docname, anchor, "", "", "")
+            )
+
+        content = sorted(content.items())
+
+        return content, True
+
+
+class ConfigDomain(Domain):
+
+    name = "config"
+    label = "Configuration Options"
+    roles = {"option": XRefRole()}
+    directives = {"option": ConfigOption}
+    indices = {ConfigIndex}
+    initial_data = {"config_options": []}
+
+    def get_objects(self):
+        yield from self.data["config_options"]
+
+    # Find the node that is being referenced
+    def resolve_xref(self, env, fromdocname, builder, typ, target,
+                     node, contnode):
+
+        # If the scope isn't specified, default to "server"
+        if ":" not in target:
+            target = "server:" + target
+
+        match = [
+            (key, docname, anchor)
+            for key, sig, typ, docname, anchor, prio in self.get_objects()
+            if anchor == target and typ == "option"
+        ]
+
+        if len(match) > 0:
+            title = match[0][0]
+            todocname = match[0][1]
+            targ = match[0][2]
+
+            refNode = make_refnode(
+                builder, fromdocname, todocname, targ,
+                child=nodes.literal(text=title)
+            )
+            refNode["classes"].append("configref")
+            return refNode
+
+        else:
+            raise SphinxWarning(
+                "Could not find target " + target + " in " + fromdocname
+            )
+            return []
+
+    # We don't want to link with "any" role, but only with "config:option"
+    def resolve_any_xref(self, env, fromdocname, builder, target, node,
+                         contnode):
+        return []
+
+    # Store the option
+    def add_option(self, key, scope):
+
+        self.data["config_options"].append(
+            (key, key, "option", self.env.docname, scope + ":" + key, 0)
+        )
+
+
+def setup(app):
+    app.add_domain(ConfigDomain)
+
+    common.add_css(app, "config-options.css")
+    common.add_js(app, "config-options.js")
+
+    return {"version": "0.1", "parallel_read_safe": True,
+            "parallel_write_safe": True}

--- a/config-options/_static/config-options.css
+++ b/config-options/_static/config-options.css
@@ -1,0 +1,41 @@
+.hide-details {
+    display: none;
+}
+
+.configoption .basicinfo::after {
+    content: "▼";
+    color: var(--color-table-border);
+    padding-right: 10px;
+}
+
+.configoption .basicinfo {
+    display: grid;
+    grid-template-columns: 2fr 4fr 1fr 10px ;
+}
+
+.configoption .shortdesc p {
+    margin: 0;
+}
+
+.configoption .basicinfo .key {
+    margin-right: 5px;
+}
+
+.configoption .details .fields {
+    list-style: none;
+    padding-left: 0;
+    font-size: smaller;
+}
+
+.ignoreP p {
+    display: inline;
+}
+
+.configoption {
+    border-bottom: 1px solid var(--color-table-border);
+    padding: 10px 0px;
+}
+
+.configoption + p {
+    margin-top: 20px;
+}

--- a/config-options/_static/config-options.js
+++ b/config-options/_static/config-options.js
@@ -1,0 +1,23 @@
+$(document).ready(function() {
+
+    /* Hide all details except if the URL has an anchor for one */
+    $('.configoption .details').addClass('hide-details');
+
+    if ($(location).attr('hash')) {
+        $('#'+$.escapeSelector($(location).attr('hash').substr(1))+" .details").removeClass('hide-details');
+    };
+
+    /* Make the option lines expandable */
+    $('.configoption div.basicinfo').click(function() {
+        $(this).nextAll('.configoption .details').first().toggleClass('hide-details');
+    });
+
+    /* When clicking a config reference, expand it automatically */
+    $('.configref').click(function() {
+        if ($(this).attr('href').substr(0,1) == "#") {
+            $('.configoption .details').addClass('hide-details');
+            $('#'+$.escapeSelector($(this).attr('href').substr(1))+" .details").removeClass('hide-details');
+        };
+    });
+
+})

--- a/config-options/common.py
+++ b/config-options/common.py
@@ -1,0 +1,1 @@
+../common.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lxd-sphinx-extensions
-version = 0.0.6
+version = 0.0.7
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used in LXD
@@ -13,6 +13,7 @@ packages =
     related-links
     youtube-links
     custom-rst-roles
+    config-options
 python_requires = >=3.6
 install_requires =
     sphinx


### PR DESCRIPTION
This adds a "{config:option}" directive to define configuration options, a "{config:option}" role to link to the configuration options, and a "{ref}`config-options`" index.