### PR TITLE
add an extension for terminal output

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,45 @@ For example, in MyST syntax:
 ```
 {ref}`config-options`
 ```
+
+### Terminal output
+
+This extension adds a `:terminal:` directive that you can use to show a terminal view with commands and output.
+You can customise the prompt and configure whether the lines should wrap.
+
+#### Enable the extension
+
+Add `terminal-output` to your extensions list in `conf.py` to enable the extension:
+
+    extensions = [
+                  (...),
+             ￼    "terminal-output"
+                 ]
+
+#### Style the output
+
+The extension comes with a CSS file that implements the classes needed to style the terminal output.
+You can override the style in your own style sheet.
+
+#### Add a terminal view
+
+To add a terminal view to your page, use the `:terminal:` directive and specify the the input (as `:input:` option) and output (as the main content of the directive).
+Any lines prefixed with `:input:` in the main content are treated as input as well.
+
+To override the prompt (`user@host:~$` by default), specify the `:user:` and/or `:host:` options.
+To make the terminal scroll horizontally instead of wrapping long lines, add `:scroll:`.
+
+For example, in MyST syntax:
+
+````
+```{terminal}
+:input: command number one
+:user: root
+:host: vm
+
+output line one
+output line two
+:input: another command
+more output
+```
+````

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ packages =
     youtube-links
     custom-rst-roles
     config-options
+    terminal-output
 python_requires = >=3.6
 install_requires =
     sphinx

--- a/terminal-output/__init__.py
+++ b/terminal-output/__init__.py
@@ -1,0 +1,78 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from . import common
+
+
+class TerminalOutput(Directive):
+
+    required_arguments = 0
+    optional_arguments = 0
+    has_content = True
+    option_spec = {
+        "input": directives.unchanged,
+        "user": directives.unchanged,
+        "host": directives.unchanged,
+        "scroll": directives.unchanged,
+    }
+
+    @staticmethod
+    def input_line(prompt_text, command):
+
+        inpline = nodes.container()
+        inpline["classes"].append("input")
+
+        prompt = nodes.literal(text=prompt_text)
+        prompt["classes"].append("prompt")
+        inpline.append(prompt)
+
+        inp = nodes.literal(text=command)
+        inp["classes"].append("command")
+        inpline.append(inp)
+
+        return inpline
+
+    def run(self):
+
+        # if :user: or :host: are provided, replace those in the prompt
+
+        command = "" if "input" not in self.options else self.options["input"]
+        user = "user" if "user" not in self.options else self.options["user"]
+        host = "host" if "host" not in self.options else self.options["host"]
+        prompt_text = user + "@" + host + ":~$ "
+        if user == "root":
+            prompt_text = prompt_text[:-2] + "# "
+
+        out = nodes.container()
+        out["classes"].append("terminal")
+        if "scroll" in self.options:
+            out["classes"].append("scroll")
+
+        # Add the original prompt and input
+
+        out.append(self.input_line(prompt_text, command))
+
+        # Go through the content and append all lines as output
+        # except for the ones that start with ":input: " - those get
+        # a prompt
+
+        for output in self.content:
+            if output.startswith(":input: "):
+                out.append(self.input_line(prompt_text, output[8:]))
+            else:
+                if output == "":
+                    output = " "
+                outp = nodes.literal(text=output)
+                outp["classes"].append("output")
+                out.append(outp)
+
+        return [out]
+
+
+def setup(app):
+    app.add_directive("terminal", TerminalOutput)
+
+    common.add_css(app, "terminal-output.css")
+
+    return {"version": "0.1", "parallel_read_safe": True,
+            "parallel_write_safe": True}

--- a/terminal-output/_static/terminal-output.css
+++ b/terminal-output/_static/terminal-output.css
@@ -1,0 +1,28 @@
+.terminal {
+    background-color: #202020;
+    color: #ebebeb;
+    border: 1px solid #666;
+    padding: 0.625rem 0;
+    overflow-x: scroll;
+}
+
+.terminal .output {
+    display: block;
+    padding: 0 0.875rem;
+    white-space: break-spaces;
+}
+
+.terminal .container.input {
+    display: block;
+    padding: 0 0.4rem 0 0.875rem;
+}
+
+.terminal .input .prompt {
+    display: inline-block;
+    font-weight: bold;
+    color: yellowgreen;
+}
+
+.terminal.scroll .input, .terminal.scroll .output {
+    width: max-content;
+}

--- a/terminal-output/common.py
+++ b/terminal-output/common.py
@@ -1,0 +1,1 @@
+../common.py


### PR DESCRIPTION
This adds a "terminal" extension that displays input and output of a command.

```{terminal}
:input: the command
:user: root
:host: vm

the output
line 2
:input: another command
more output
```

":user:" and ":host:" are optional, as is including more ":input" lines.
You can add ":scroll:" to prevent long lines from breaking.