### PR TITLE
fix placement of YouTube link

### DIFF
--- a/youtube-links/_static/youtube.css
+++ b/youtube-links/_static/youtube.css
@@ -26,3 +26,8 @@ p.youtube_link span {
     font-size: small;
     max-width: 70px;
 }
+
+/* The YouTube link should not span into the next section */
+section {
+    clear: right;
+}


### PR DESCRIPTION
Clear the section so that a link before a new section does not extend into the new heading.