### PR TITLE
improve the styling of the config option output

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ Add `config-options` to your extensions list in `conf.py` to enable the extensio
 #### Style the output
 
 The extension comes with a CSS file that implements the classes needed to style the configuration options.
+This CSS file requires the following colour variables to be defined:
+
+- `color-content-foreground`: normal text colour
+- `color-link`: link text colour
+- `color-table-border`: colour for table borders
+- `color-orange`: contrast colour (used for table cell background)
+
 You can override the style in your own style sheet.
 
 #### Add configuration options

--- a/config-options/_static/config-options.css
+++ b/config-options/_static/config-options.css
@@ -1,16 +1,11 @@
-.hide-details {
-    display: none;
-}
-
-.configoption .basicinfo::after {
-    content: "▼";
-    color: var(--color-table-border);
-    padding-right: 10px;
+.details[hidden="until-found"] {
+    display: inherit;
 }
 
 .configoption .basicinfo {
     display: grid;
-    grid-template-columns: 2fr 4fr 1fr 10px ;
+    grid-template-columns: 25ch auto 2ch;
+    cursor: pointer;
 }
 
 .configoption .shortdesc p {
@@ -21,14 +16,31 @@
     margin-right: 5px;
 }
 
-.configoption .details .fields {
-    list-style: none;
-    padding-left: 0;
+.configoption .details table.fields {
     font-size: smaller;
+    border: 1px solid var(--color-orange);
+    width: auto;
+    margin-left: 10px;
+}
+
+.configoption .details table.fields tr td:first-child {
+    background-color: var(--color-orange);
+}
+
+table.fields td {
+    border-bottom: 0;
 }
 
 .ignoreP p {
     display: inline;
+}
+
+.configoption .basicinfo .anchor i svg {
+    transform: rotate(90deg);
+}
+
+.configoption .basicinfo .anchor a {
+    color: var(--color-content-foreground);
 }
 
 .configoption {
@@ -38,4 +50,16 @@
 
 .configoption + p {
     margin-top: 20px;
+}
+
+.expand-collapse {
+    text-align: right;
+    margin-right: 5px;
+    cursor: pointer;
+}
+
+#expand-options {
+    text-align: right;
+    color: var(--color-link);
+    cursor: pointer;
 }

--- a/config-options/_static/config-options.js
+++ b/config-options/_static/config-options.js
@@ -1,23 +1,52 @@
 $(document).ready(function() {
 
     /* Hide all details except if the URL has an anchor for one */
-    $('.configoption .details').addClass('hide-details');
+    $('.configoption div.details').prop("hidden","until-found");
 
     if ($(location).attr('hash')) {
-        $('#'+$.escapeSelector($(location).attr('hash').substr(1))+" .details").removeClass('hide-details');
+        $('#'+$.escapeSelector($(location).attr('hash').substr(1))+" .details").removeAttr("hidden");
     };
+
+    /* Add icons to expand/collapse all options for one section */
+    $('.configoption:first-of-type').before("<div class=\"expand-collapse\"><span class=\"expand-all\" title=\"Expand all\">⤋</span><span class=\"collapse-all\" title=\"Collapse all\">⤊</span></div>");
 
     /* Make the option lines expandable */
     $('.configoption div.basicinfo').click(function() {
-        $(this).nextAll('.configoption .details').first().toggleClass('hide-details');
+        if ($(this).nextAll('.configoption .details').first().prop("hidden")) {
+            $(this).nextAll('.configoption .details').first().removeAttr("hidden");
+        }
+        else {
+            $(this).nextAll('.configoption .details').first().prop("hidden","until-found");
+        }
+    });
+
+    /* Expand/collapse all options in a section */
+    $('.expand-all').click(function() {
+        $(this).parent().nextAll('.configoption').find('.details').removeAttr("hidden");
+    });
+
+    $('.collapse-all').click(function() {
+        $(this).parent().nextAll('.configoption').find('.details').prop("hidden","until-found");
     });
 
     /* When clicking a config reference, expand it automatically */
     $('.configref').click(function() {
         if ($(this).attr('href').substr(0,1) == "#") {
-            $('.configoption .details').addClass('hide-details');
-            $('#'+$.escapeSelector($(this).attr('href').substr(1))+" .details").removeClass('hide-details');
+            $('.configoption div.details').prop("hidden","until-found");
+            $('#'+$.escapeSelector($(this).attr('href').substr(1))+" .details").removeAttr("hidden");
         };
     });
+
+    /* If searching in hidden content is not supported, add an
+       "Expand all options" link at the top of the page. */
+    if (!('onbeforematch' in document.body)) {
+        $('.main .content article h1:first-of-type').after("<div id=\"expand-options\">⤋ Expand all options</div>");
+
+        $('#expand-options').click(function() {
+            $('.configoption div.details').removeAttr("hidden");
+
+        });
+    };
+
 
 })


### PR DESCRIPTION
- Change the cursor to a pointer when hovering over the line
- Change the drop-down icon to be more visible
- Add an anchor link to the drop-down icon
- Move the default to the field table (otherwise, there isn't
  enough space for the description)
- Use a fixed width for the grid columns
- Style the fields in a table
- Add an expand/collapse icon to each option section
- Use "hidden=until-found" to make descriptions searchable
- Add an "Expand all" link in browsers where hidden descriptions
  cannot be searched