### PR TITLE
restrict which config options we expand

### DIFF
--- a/config-options/_static/config-options.js
+++ b/config-options/_static/config-options.js
@@ -4,7 +4,7 @@ $(document).ready(function() {
     $('.configoption div.details').prop("hidden","until-found");
 
     if ($(location).attr('hash')) {
-        $('#'+$.escapeSelector($(location).attr('hash').substr(1))+" .details").removeAttr("hidden");
+        $('div#'+$.escapeSelector($(location).attr('hash').substr(1))+" > .details").removeAttr("hidden");
     };
 
     /* Add icons to expand/collapse all options for one section */

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lxd-sphinx-extensions
-version = 0.0.10
+version = 0.0.11
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used in LXD


### PR DESCRIPTION
Currently, when linking to a section on a page, all config options in the section are expanded. The function is meant to only expand single config options when linked to.