### PR TITLE
config-options: Add 'initialvaluedesc' option field needed for "Project features" section

### DIFF
--- a/config-options/__init__.py
+++ b/config-options/__init__.py
@@ -27,6 +27,7 @@ class ConfigOption(ObjectDescription):
         "type": "Type",
         "default": "Default",
         "defaultdesc": "Default",
+        "initialvaluedesc": "Initial value",
         "liveupdate": "Live update",
         "condition": "Condition",
         "readonly": "Read-only",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lxd-sphinx-extensions
-version = 0.0.12
+version = 0.0.13
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used in LXD


### PR DESCRIPTION
We will need a new key title for "Initial value", see [here](https://documentation.ubuntu.com/lxd/en/latest/reference/projects/#:~:text=is%20false.-,KEY,DESCRIPTION,-features.images)