### PR TITLE
add a filtered-toc extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,3 +281,55 @@ output line two
 more output
 ```
 ````
+
+### Filtered ToC
+
+This extension adds a `:filtered-toctree:` directive that is almost the same as the normal `:toctree:` directive but allows excluding pages based on specified filters.
+
+#### Enable the extension
+
+Add `filtered-toc` to your extensions list in `conf.py` to enable the extension:
+
+    extensions = [
+                  (...),
+             ￼    "filtered-toc"
+                 ]
+
+#### Configure the filters
+
+Define filters that you want to exclude from your documentation in the `toc_filter_exclude` variable in your `conf.py`.
+For example:
+
+    toc_filter_exclude = ['draft','internal']
+
+You can use environment variables or build parameters to distinguish between different settings for the `toc_filter_exclude` variable in your `conf.py`.
+For example:
+
+    if ('TOPICAL' in os.environ) and (os.environ['TOPICAL'] == 'True'):
+        toc_filter_exclude = ['diataxis']
+    else:
+        toc_filter_exclude = ['topical']
+
+#### Use the `:filtered-toctree:` directive
+
+The `:filtered-toctree:` directive works just as the normal `:toctree:` directive, but you can add a filter to each line.
+The filter must start and end with a colon (`:`) and contains any string in between.
+The string between the colons is what you would specify in the `toc_filter_exclude` variable (however, you can use any string, even if it's not specified in the `toc_filter_exclude` variable).
+
+You can put the filter either at the front of the line or right in front of the file name or path.
+You can only specify one filter per line.
+
+For example, in MyST syntax:
+
+````
+```{filtered-toctree}
+:maxdepth: 1
+
+:internal:/tutorial/first_steps
+:draft:Installation </installing>
+Get support <:external:/support>
+```
+````
+
+In this case, all three topics would be included by default.
+When setting `toc_filter_exclude = ['draft','internal']`, only `Get support` would be included.

--- a/filtered-toc/__init__.py
+++ b/filtered-toc/__init__.py
@@ -1,0 +1,43 @@
+import re
+from sphinx.directives.other import TocTree
+
+
+def setup(app):
+    app.add_config_value("toc_filter_exclude", [], "html")
+    app.add_directive("filtered-toctree", FilteredTocTree)
+    return {"version": "1.0.0"}
+
+
+class FilteredTocTree(TocTree):
+
+    findFilter = re.compile(r"^\s*:(.+?):.+$|^.*<:(.+?):.+>$")
+
+    # Go through all toctree entries and check if they should be included.
+    # If they should be included, remove the filter (":something:").
+    def filter_entries(self, entries):
+        excl = self.state.document.settings.env.config.toc_filter_exclude
+        filtered = []
+        for e in entries:
+            m = self.findFilter.match(e)
+
+            if m is not None:
+                # The filter is in different matches depending on whether
+                # we override the title and where we put the filter
+                if e.startswith(":"):
+                    filt = m.groups()[0]
+                elif e.endswith(">"):
+                    filt = m.groups()[1]
+                else:
+                    filt = m.groups()[0]
+
+                # Keep the entries that are not supposed to be excluded
+                if filt not in excl:
+                    filtered.append(e.replace(":" + filt + ":", ""))
+            else:
+                filtered.append(e)
+        return filtered
+
+    def run(self):
+        # Remove all TOC entries that should not be included
+        self.content = self.filter_entries(self.content)
+        return super().run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lxd-sphinx-extensions
-version = 0.0.13
+version = 0.0.14
 author = Ruth Fuchss
 author_email = ruth.fuchss@canonical.com
 description = A collection of Sphinx extensions used in LXD
@@ -15,6 +15,7 @@ packages =
     custom-rst-roles
     config-options
     terminal-output
+    filtered-toc
 python_requires = >=3.6
 install_requires =
     sphinx


### PR DESCRIPTION
Add an extension that allows to filter toctree entries based on tags specified in the conf file.