### PR TITLE
config-options: add call to requestAnimationFrame

### DIFF
--- a/canonical-sphinx-extensions/config-options/_static/config-options.js
+++ b/canonical-sphinx-extensions/config-options/_static/config-options.js
@@ -1,5 +1,8 @@
 $(document).ready(function() {
 
+    /* Request one frame to avoid scrolling before collapsing content */
+    window.requestAnimationFrame();
+
     /* Hide all details except if the URL has an anchor for one */
     $('.configoption div.details').prop("hidden","until-found");
 


### PR DESCRIPTION
This commit fixes the scrolling behavior on page load. Before that, anchor scrolling would be computed on the expanded configuration.