### PR TITLE
chore: prepare repo for archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+> [!IMPORTANT]
+> canonical-sphinx-extensions has been superseded by the standalone extensions and will
+> no longer be maintained. All issues and contributions should be opened against the new
+> repositories.
+>
+> * [sphinx-config-options](https://github.com/canonical/sphinx-config-options)
+> * [sphinx-contributor-listing](https://github.com/canonical/sphinx-contributor-listing)
+> * [sphinx-filtered-toctree](https://github.com/canonical/sphinx-filtered-toctree)
+> * [sphinx-related-links](https://github.com/canonical/sphinx-related-links)
+> * [sphinx-roles](https://github.com/canonical/sphinx-roles)
+> * [sphinx-terminal](https://github.com/canonical/sphinx-terminal)
+> * [sphinx-ubuntu-images](https://github.com/canonical/sphinx-ubuntu-images)
+> * [sphinx-youtube-links](https://github.com/canonical/sphinx-youtube-links)
+
 # Canonical Sphinx extensions
 
 This package provides several Sphinx extensions that are used in Canonical documentation (for example, in the [documentation starter pack](https://github.com/canonical/sphinx-docs-starter-pack)).

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 > longer maintained. All issues and contributions should be opened against the new
 > repositories.
 >
-> * [sphinx-config-options](https://github.com/canonical/sphinx-config-options)
-> * [sphinx-contributor-listing](https://github.com/canonical/sphinx-contributor-listing)
-> * [sphinx-filtered-toctree](https://github.com/canonical/sphinx-filtered-toctree)
-> * [sphinx-related-links](https://github.com/canonical/sphinx-related-links)
-> * [sphinx-roles](https://github.com/canonical/sphinx-roles)
-> * [sphinx-terminal](https://github.com/canonical/sphinx-terminal)
-> * [sphinx-ubuntu-images](https://github.com/canonical/sphinx-ubuntu-images)
-> * [sphinx-youtube-links](https://github.com/canonical/sphinx-youtube-links)
+> * [sphinx-config-options](https://github.com/canonical/sphinx-config-options): `config:option`
+> * [sphinx-contributor-listing](https://github.com/canonical/sphinx-contributor-listing): `contributor-listing`
+> * [sphinx-filtered-toctree](https://github.com/canonical/sphinx-filtered-toctree): `filtered-toctree`
+> * [sphinx-related-links](https://github.com/canonical/sphinx-related-links): `discourse` and `relatedlinks`
+> * [sphinx-roles](https://github.com/canonical/sphinx-roles): `literalref`, `spellexception`, and `none`
+> * [sphinx-terminal](https://github.com/canonical/sphinx-terminal): `terminal`
+> * [sphinx-ubuntu-images](https://github.com/canonical/sphinx-ubuntu-images): `ubuntu-images`
+> * [sphinx-youtube-links](https://github.com/canonical/sphinx-youtube-links): `youtube`
 
 # Canonical Sphinx extensions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > [!IMPORTANT]
-> canonical-sphinx-extensions has been superseded by the standalone extensions and will
-> no longer be maintained. All issues and contributions should be opened against the new
+> canonical-sphinx-extensions has been superseded by the standalone extensions and is no
+> longer maintained. All issues and contributions should be opened against the new
 > repositories.
 >
 > * [sphinx-config-options](https://github.com/canonical/sphinx-config-options)


### PR DESCRIPTION
Give notice that this repository will no longer be maintained

[Rendered doc](https://github.com/canonical/canonical-sphinx-extensions/blob/work/archive-prep/README.md)